### PR TITLE
Transport Protocol Definition

### DIFF
--- a/src/network/__init__.py
+++ b/src/network/__init__.py
@@ -1,0 +1,25 @@
+"""Network abstraction layer."""
+
+from src.network.messages import (
+    FindSuccessorRequest,
+    FindSuccessorResponse,
+    JoinRequest,
+    JoinResponse,
+    NodeAddress,
+    NodeInfo,
+    NotifyRequest,
+    PredecessorResponse,
+)
+from src.network.protocol import Transport
+
+__all__ = [
+    "Transport",
+    "NodeAddress",
+    "NodeInfo",
+    "JoinRequest",
+    "JoinResponse",
+    "FindSuccessorRequest",
+    "FindSuccessorResponse",
+    "NotifyRequest",
+    "PredecessorResponse",
+]

--- a/src/network/messages.py
+++ b/src/network/messages.py
@@ -1,0 +1,70 @@
+"""Message types for inter-node communication."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NodeAddress:
+    """Network address of a node."""
+
+    host: str
+    port: int
+
+    def __str__(self) -> str:
+        return f"{self.host}:{self.port}"
+
+
+@dataclass(frozen=True)
+class NodeInfo:
+    """Node identity and address."""
+
+    node_id: int
+    address: NodeAddress
+
+
+@dataclass(frozen=True)
+class JoinRequest:
+    """Request to join the ring."""
+
+    node_id: int
+    address: NodeAddress
+
+
+@dataclass(frozen=True)
+class JoinResponse:
+    """Response to join request with successor info."""
+
+    successor_id: int
+    successor_address: NodeAddress
+
+
+@dataclass(frozen=True)
+class FindSuccessorRequest:
+    """Request to find successor of a key."""
+
+    key: int
+    requester_address: NodeAddress
+
+
+@dataclass(frozen=True)
+class FindSuccessorResponse:
+    """Response with successor info."""
+
+    successor_id: int
+    successor_address: NodeAddress
+
+
+@dataclass(frozen=True)
+class NotifyRequest:
+    """Notify a node about its potential predecessor."""
+
+    predecessor_id: int
+    predecessor_address: NodeAddress
+
+
+@dataclass(frozen=True)
+class PredecessorResponse:
+    """Response with predecessor info."""
+
+    predecessor_id: int | None
+    predecessor_address: NodeAddress | None

--- a/src/network/protocol.py
+++ b/src/network/protocol.py
@@ -1,0 +1,74 @@
+"""Abstract transport protocol for inter-node communication."""
+
+from typing import Protocol
+
+from src.network.messages import (
+    FindSuccessorResponse,
+    JoinResponse,
+    NodeAddress,
+    PredecessorResponse,
+)
+
+
+class Transport(Protocol):
+    """Abstract network transport for Chord inter-node communication."""
+
+    async def join(
+        self, target: NodeAddress, node_id: int, node_address: NodeAddress
+    ) -> JoinResponse:
+        """Send join request to a node."""
+        ...
+
+    async def find_successor(
+        self,
+        target: NodeAddress,
+        key: int,
+        requester_address: NodeAddress,
+    ) -> FindSuccessorResponse:
+        """Request successor of a key from a node."""
+        ...
+
+    async def notify(
+        self,
+        target: NodeAddress,
+        predecessor_id: int,
+        predecessor_address: NodeAddress,
+    ) -> bool:
+        """Notify a node about its potential predecessor."""
+        ...
+
+    async def get_predecessor(
+        self,
+        target: NodeAddress,
+    ) -> PredecessorResponse:
+        """Get predecessor info from a node."""
+        ...
+
+    async def forward_file(
+        self,
+        target: NodeAddress,
+        filename: str,
+        content: bytes,
+    ) -> bool:
+        """Forward a file to the responsible node."""
+        ...
+
+    async def get_file(
+        self,
+        target: NodeAddress,
+        filename: str,
+    ) -> bytes | None:
+        """Retrieve a file from a node."""
+        ...
+
+    async def delete_file(
+        self,
+        target: NodeAddress,
+        filename: str,
+    ) -> bool:
+        """Delete a file from a node."""
+        ...
+
+    async def ping(self, target: NodeAddress) -> bool:
+        """Check if a node is alive (failure detection)."""
+        ...


### PR DESCRIPTION
This pull request introduces a new network abstraction layer for inter-node communication, focusing on the definition of message types and an abstract transport protocol. The changes lay the groundwork for a modular and type-safe network layer, making it easier to implement and test Chord protocol networking.

**Network abstraction and message definitions:**

* Added a new `src/network/messages.py` module defining all message types used for inter-node communication, such as `NodeAddress`, `NodeInfo`, `JoinRequest`, `FindSuccessorRequest`, and their respective responses, using frozen dataclasses for immutability and clarity.
* Created a new `src/network/protocol.py` file that defines the `Transport` protocol, specifying all required asynchronous methods for Chord node communication (e.g., `join`, `find_successor`, `notify`, file operations, and `ping`). This abstraction allows for different transport implementations (e.g., TCP, HTTP) to be swapped in easily.