### PR TITLE
Unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "chord-dfs"
 version = "0.1.0"
@@ -53,3 +57,6 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "raise NotImplementedError",
 ]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/tests/unit/test_finger_table.py
+++ b/tests/unit/test_finger_table.py
@@ -1,0 +1,156 @@
+"""Tests for FingerTable class."""
+
+import pytest
+
+from src.core.finger_table import FingerTable
+from src.core.hashing import DEFAULT_M_BITS
+from src.network.messages import NodeAddress, NodeInfo
+
+
+@pytest.fixture
+def node_address():
+    """Create a test node address."""
+    return NodeAddress(host="localhost", port=5000)
+
+
+@pytest.fixture
+def finger_table(node_address):
+    """Create a finger table for testing."""
+    return FingerTable(node_id=100, node_address=node_address)
+
+
+@pytest.fixture
+def other_node():
+    """Create another node for testing."""
+    return NodeInfo(node_id=200, address=NodeAddress(host="localhost", port=5001))
+
+
+class TestFingerTableInit:
+    """Tests for FingerTable initialization."""
+
+    def test_init_with_defaults(self, node_address):
+        """Initialize with default m_bits."""
+        ft = FingerTable(node_id=100, node_address=node_address)
+        assert ft.node_id == 100
+        assert ft.node_address == node_address
+        assert ft.m_bits == DEFAULT_M_BITS
+
+    def test_init_custom_m_bits(self, node_address):
+        """Initialize with custom m_bits."""
+        ft = FingerTable(node_id=100, node_address=node_address, m_bits=8)
+        assert ft.m_bits == 8
+
+    def test_init_entries_point_to_self(self, finger_table, node_address):
+        """All entries initially point to self."""
+        for i in range(1, finger_table.m_bits + 1):
+            entry = finger_table.get(i)
+            assert entry.node_id == 100
+            assert entry.address == node_address
+
+
+class TestFingerTableOperations:
+    """Tests for FingerTable operations."""
+
+    def test_fill(self, finger_table, other_node):
+        """Fill all entries with a node."""
+        finger_table.fill(other_node)
+        for i in range(1, finger_table.m_bits + 1):
+            assert finger_table.get(i) == other_node
+
+    def test_update_single_entry(self, finger_table, other_node):
+        """Update a single entry."""
+        finger_table.update(1, other_node)
+        assert finger_table.get(1) == other_node
+        # Other entries unchanged
+        assert finger_table.get(2).node_id == 100
+
+    def test_update_various_indices(self, finger_table, node_address):
+        """Update entries at various indices."""
+        for i in range(1, finger_table.m_bits + 1):
+            new_node = NodeInfo(node_id=i * 100, address=node_address)
+            finger_table.update(i, new_node)
+            assert finger_table.get(i).node_id == i * 100
+
+    def test_get_uses_one_based_index(self, finger_table, other_node):
+        """Get uses 1-based indexing."""
+        finger_table.update(1, other_node)
+        assert finger_table.get(1) == other_node
+
+
+class TestFingerTableSuccessor:
+    """Tests for successor property."""
+
+    def test_successor_is_first_entry(self, finger_table, other_node):
+        """Successor is the first finger table entry."""
+        finger_table.update(1, other_node)
+        assert finger_table.successor == other_node
+
+    def test_successor_initially_self(self, finger_table):
+        """Successor initially points to self."""
+        assert finger_table.successor.node_id == finger_table.node_id
+
+
+class TestFindClosestPreceding:
+    """Tests for find_closest_preceding method."""
+
+    def test_returns_self_when_no_better_option(self, finger_table):
+        """Returns first entry when no closer node exists."""
+        result = finger_table.find_closest_preceding(500)
+        assert result.node_id == finger_table.node_id
+
+    def test_finds_closest_preceding(self, node_address):
+        """Finds the closest preceding node from finger table."""
+        ft = FingerTable(node_id=0, node_address=node_address)
+
+        # Set up finger table entries
+        ft.update(1, NodeInfo(node_id=100, address=node_address))
+        ft.update(2, NodeInfo(node_id=200, address=node_address))
+        ft.update(3, NodeInfo(node_id=400, address=node_address))
+
+        # Key 350 should return node 200 (closest preceding)
+        result = ft.find_closest_preceding(350)
+        assert result.node_id == 200
+
+    def test_scans_from_highest_to_lowest(self, node_address):
+        """Scans finger table from highest index to lowest."""
+        ft = FingerTable(node_id=0, node_address=node_address, m_bits=4)
+
+        # Fill with increasing node IDs
+        for i in range(1, 5):
+            ft.update(i, NodeInfo(node_id=i * 50, address=node_address))
+
+        # Key 250: should find node 200 (index 4)
+        result = ft.find_closest_preceding(250)
+        assert result.node_id == 200
+
+
+class TestGetRefreshTargets:
+    """Tests for get_refresh_targets method."""
+
+    def test_returns_correct_number_of_targets(self, finger_table):
+        """Returns m_bits number of targets."""
+        targets = finger_table.get_refresh_targets()
+        assert len(targets) == finger_table.m_bits
+
+    def test_targets_have_correct_structure(self, finger_table):
+        """Each target is (index, lookup_key) tuple."""
+        targets = finger_table.get_refresh_targets()
+        for index, lookup_key in targets:
+            assert isinstance(index, int)
+            assert isinstance(lookup_key, int)
+            assert 1 <= index <= finger_table.m_bits
+
+    def test_lookup_keys_formula(self, node_address):
+        """Lookup keys follow (node_id + 2^(i-1)) mod 2^m formula."""
+        ft = FingerTable(node_id=100, node_address=node_address, m_bits=4)
+        targets = ft.get_refresh_targets()
+
+        expected_keys = [
+            (100 + 1) % 16,  # i=1: 100 + 2^0 = 101 % 16 = 5
+            (100 + 2) % 16,  # i=2: 100 + 2^1 = 102 % 16 = 6
+            (100 + 4) % 16,  # i=3: 100 + 2^2 = 104 % 16 = 8
+            (100 + 8) % 16,  # i=4: 100 + 2^3 = 108 % 16 = 12
+        ]
+
+        for (_index, key), expected_key in zip(targets, expected_keys, strict=True):
+            assert key == expected_key

--- a/tests/unit/test_hashing.py
+++ b/tests/unit/test_hashing.py
@@ -1,0 +1,104 @@
+"""Tests for consistent hashing utilities."""
+
+import pytest
+
+from src.core.hashing import DEFAULT_M_BITS, dht_hash, is_between
+
+
+class TestDhtHash:
+    """Tests ofr dht_hash function."""
+
+    def test_hash_string(self):
+        """Hash a string and get an integer result."""
+        result = dht_hash("test")
+        assert isinstance(result, int)
+
+    def test_hash_bytes(self):
+        """Hash bytes directly."""
+        result = dht_hash(b"test")
+        assert isinstance(result, int)
+
+    def test_hash_deterministic(self):
+        """Same input produces same output."""
+        assert dht_hash("hello") == dht_hash("hello")
+        assert dht_hash(b"hello") == dht_hash(b"hello")
+
+    def test_hash_string_bytes_equivalent(self):
+        """String and its encoded bytes produce same hash."""
+        assert dht_hash("hello") == dht_hash(b"hello")
+
+    def test_hash_in_range(self):
+        """Hash is within [0, 2^m_bits]."""
+        max_value = 2**DEFAULT_M_BITS
+        for data in ["test", "node0:5000", "file.txt", ""]:
+            result = dht_hash(data)
+            assert 0 <= result < max_value
+
+    def test_hash_custom__m_bits(self):
+        """Hash respects custom m_bits parameter."""
+        result = dht_hash("test", m_bits=8)
+        assert 0 <= result <= 256
+        result = dht_hash("test", m_bits=16)
+        assert 0 <= result <= 65536
+
+    def test_hash_different_inputs(self):
+        """Different inputs produce different hashes (with high probability)."""
+        # With 10-bit hash (1024 values), use fewer inputs to avoid birthday paradox
+        hashes = {dht_hash(f"node{i}") for i in range(100)}
+        assert len(hashes) > 90
+
+
+class TestIsBetween:
+    """Tests for is_between circular range check."""
+
+    def test_normal_range(self):
+        """Value in normal (non-wraparound) range."""
+        assert is_between(10, 20, 15) is True
+        assert is_between(10, 20, 10) is False
+        assert is_between(10, 20, 20) is True
+
+    def test_outside_normal_range(self):
+        """Value ourside normal range."""
+        assert is_between(10, 20, 5) is False
+        assert is_between(10, 20, 25) is False
+
+    def test_wraparound_range(self):
+        """Value in wraparound range (start > end)"""
+        # Range (900, 100] on 1024-space wraps around 0
+        assert is_between(900, 100, 950) is True  # after start
+        assert is_between(900, 100, 50) is True  # before end
+        assert is_between(900, 100, 0) is True  # at zero
+        assert is_between(900, 100, 100) is True  # at end
+
+    def test_outside_wraparound_range(self):
+        """Value outside wraparound range."""
+        assert is_between(900, 100, 500) is False
+        assert is_between(900, 100, 200) is False
+        assert is_between(900, 100, 900) is False
+
+    def test_adjacent_values(self):
+        """Edge cases with adjacent values."""
+        assert is_between(5, 6, 6) is True
+        assert is_between(5, 6, 5) is False
+
+    def test_same_start_end(self):
+        """When start equals end, all values are in range (full circle)."""
+        # This represents a single-node ring where the node is responsible for all keys
+        assert is_between(10, 10, 10) is True
+        assert is_between(10, 10, 5) is True
+        assert is_between(10, 10, 100) is True
+
+    @pytest.mark.parametrize(
+        ("start", "end", "value", "expected"),
+        [
+            (0, 100, 50, True),
+            (0, 100, 0, False),
+            (0, 100, 100, True),
+            (1000, 50, 1020, True),
+            (1000, 50, 30, True),
+            (1000, 50, 500, False),
+        ],
+    )
+    def test_parametrized_cases(self, start, end, value, expected):
+        """Parametrized test cases for comprehensive coverage."""
+        assert is_between(start, end, value) is expected

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -1,0 +1,214 @@
+"""Tests for ChordNode class."""
+
+import pytest
+
+from src.core.node import ChordNode
+from src.network.messages import NodeAddress, NodeInfo
+
+
+@pytest.fixture
+def node_address():
+    """Create a test node address."""
+    return NodeAddress(host="localhost", port=5000)
+
+
+@pytest.fixture
+def chord_node(node_address):
+    """Create a ChordNode for testing."""
+    return ChordNode(node_id=100, address=node_address)
+
+
+@pytest.fixture
+def other_node():
+    """Create another node for testing."""
+    return NodeInfo(node_id=200, address=NodeAddress(host="localhost", port=5001))
+
+
+class TestChordNodeInit:
+    """Tests for ChordNode initialization."""
+
+    def test_init_basic(self, node_address):
+        """Initialize a ChordNode."""
+        node = ChordNode(node_id=100, address=node_address)
+        assert node.node_id == 100
+        assert node.address == node_address
+        assert node.predecessor is None
+
+    def test_init_creates_finger_table(self, chord_node):
+        """Finger table is created on init."""
+        assert chord_node.finger_table is not None
+        assert chord_node.finger_table.node_id == chord_node.node_id
+
+    def test_info_property(self, chord_node, node_address):
+        """Info property returns NodeInfo."""
+        info = chord_node.info
+        assert info.node_id == 100
+        assert info.address == node_address
+
+    def test_successor_initially_self(self, chord_node):
+        """Successor initially points to self."""
+        assert chord_node.successor.node_id == chord_node.node_id
+
+    def test_is_alone_initially(self, chord_node):
+        """Node is alone when successor is self."""
+        assert chord_node.is_alone() is True
+
+
+class TestKeyResponsibility:
+    """Tests for is_responsible_for method."""
+
+    def test_responsible_when_no_predecessor(self, chord_node):
+        """Responsible for all keys when no predecessor."""
+        assert chord_node.is_responsible_for(50) is True
+        assert chord_node.is_responsible_for(150) is True
+        assert chord_node.is_responsible_for(100) is True
+
+    def test_responsible_for_keys_in_range(self, chord_node):
+        """Responsible for keys in (predecessor, self]."""
+        chord_node.predecessor = NodeInfo(
+            node_id=50, address=NodeAddress(host="localhost", port=5001)
+        )
+        # Keys in (50, 100]
+        assert chord_node.is_responsible_for(75) is True
+        assert chord_node.is_responsible_for(100) is True
+        assert chord_node.is_responsible_for(50) is False  # exclusive start
+
+    def test_not_responsible_for_keys_outside_range(self, chord_node):
+        """Not responsible for keys outside (predecessor, self]."""
+        chord_node.predecessor = NodeInfo(
+            node_id=50, address=NodeAddress(host="localhost", port=5001)
+        )
+        assert chord_node.is_responsible_for(25) is False
+        assert chord_node.is_responsible_for(150) is False
+
+    def test_responsible_with_wraparound(self, node_address):
+        """Handle wraparound case correctly."""
+        node = ChordNode(node_id=50, address=node_address)
+        node.predecessor = NodeInfo(node_id=900, address=NodeAddress(host="localhost", port=5001))
+        # Keys in (900, 50] with wraparound
+        assert node.is_responsible_for(950) is True
+        assert node.is_responsible_for(0) is True
+        assert node.is_responsible_for(50) is True
+        assert node.is_responsible_for(500) is False
+
+
+class TestRouting:
+    """Tests for routing methods."""
+
+    def test_closest_preceding_node_delegates(self, chord_node):
+        """closest_preceding_node delegates to finger table."""
+        result = chord_node.closest_preceding_node(500)
+        assert result.node_id == chord_node.node_id
+
+    def test_find_successor_local_found(self, chord_node, other_node):
+        """find_successor_local returns successor when key in range."""
+        chord_node.set_successor(other_node)
+        # Key in (100, 200]
+        result = chord_node.find_successor_local(150)
+        assert result == other_node
+
+    def test_find_successor_local_not_found(self, chord_node, other_node):
+        """find_successor_local returns None when key not in range."""
+        chord_node.set_successor(other_node)
+        # Key not in (100, 200]
+        result = chord_node.find_successor_local(250)
+        assert result is None
+
+    def test_get_forward_target(self, chord_node):
+        """get_forward_target returns closest preceding node."""
+        result = chord_node.get_forward_target(500)
+        # Initially returns self (finger table points to self)
+        assert result.node_id == chord_node.node_id
+
+
+class TestStabilization:
+    """Tests for stabilization logic."""
+
+    def test_should_update_successor_none_predecessor(self, chord_node):
+        """Don't update when successor's predecessor is None."""
+        assert chord_node.should_update_successor(None) is False
+
+    def test_should_update_successor_when_alone(self, chord_node):
+        """Update successor when alone and predecessor differs."""
+        new_node = NodeInfo(node_id=150, address=NodeAddress(host="localhost", port=5001))
+        assert chord_node.should_update_successor(new_node) is True
+
+    def test_should_update_successor_when_alone_same_node(self, chord_node):
+        """Don't update when alone and predecessor is us."""
+        same_node = NodeInfo(node_id=100, address=chord_node.address)
+        assert chord_node.should_update_successor(same_node) is False
+
+    def test_should_update_successor_better_node(self, chord_node, other_node):
+        """Update when there's a better successor."""
+        chord_node.set_successor(other_node)  # successor = 200
+
+        # Node 150 is between us (100) and successor (200)
+        better_node = NodeInfo(node_id=150, address=NodeAddress(host="localhost", port=5002))
+        assert chord_node.should_update_successor(better_node) is True
+
+    def test_should_not_update_successor_worse_node(self, chord_node, other_node):
+        """Don't update when node is not between us and successor."""
+        chord_node.set_successor(other_node)  # successor = 200
+
+        # Node 250 is not between us (100) and successor (200)
+        worse_node = NodeInfo(node_id=250, address=NodeAddress(host="localhost", port=5002))
+        assert chord_node.should_update_successor(worse_node) is False
+
+
+class TestNotify:
+    """Tests for notify method."""
+
+    def test_notify_sets_predecessor_when_none(self, chord_node, other_node):
+        """Notify sets predecessor when none exists."""
+        result = chord_node.notify(other_node)
+        assert result is True
+        assert chord_node.predecessor == other_node
+
+    def test_notify_updates_better_predecessor(self, chord_node):
+        """Notify updates predecessor when new node is closer."""
+        old_pred = NodeInfo(node_id=50, address=NodeAddress(host="localhost", port=5001))
+        chord_node.predecessor = old_pred
+
+        # Node 75 is between 50 and 100 (us)
+        better_pred = NodeInfo(node_id=75, address=NodeAddress(host="localhost", port=5002))
+        result = chord_node.notify(better_pred)
+        assert result is True
+        assert chord_node.predecessor == better_pred
+
+    def test_notify_ignores_worse_predecessor(self, chord_node):
+        """Notify ignores new node that's not closer."""
+        old_pred = NodeInfo(node_id=75, address=NodeAddress(host="localhost", port=5001))
+        chord_node.predecessor = old_pred
+
+        # Node 50 is not between 75 and 100 (us)
+        worse_pred = NodeInfo(node_id=50, address=NodeAddress(host="localhost", port=5002))
+        result = chord_node.notify(worse_pred)
+        assert result is False
+        assert chord_node.predecessor == old_pred
+
+
+class TestStateUpdates:
+    """Tests for state update methods."""
+
+    def test_set_successor(self, chord_node, other_node):
+        """set_successor updates finger table entry 1."""
+        chord_node.set_successor(other_node)
+        assert chord_node.successor == other_node
+        assert chord_node.is_alone() is False
+
+    def test_set_predecessor(self, chord_node, other_node):
+        """set_predecessor updates predecessor."""
+        chord_node.set_predecessor(other_node)
+        assert chord_node.predecessor == other_node
+
+    def test_set_predecessor_none(self, chord_node, other_node):
+        """set_predecessor can set to None."""
+        chord_node.predecessor = other_node
+        chord_node.set_predecessor(None)
+        assert chord_node.predecessor is None
+
+    def test_clear_predecessor(self, chord_node, other_node):
+        """clear_predecessor sets predecessor to None."""
+        chord_node.predecessor = other_node
+        chord_node.clear_predecessor()
+        assert chord_node.predecessor is None

--- a/uv.lock
+++ b/uv.lock
@@ -62,7 +62,7 @@ wheels = [
 [[package]]
 name = "chord-dfs"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "fastapi" },


### PR DESCRIPTION
This pull request introduces a comprehensive suite of unit tests for the core components of the Chord distributed hash table implementation, and adds Python packaging configuration for building wheels. The most important changes include new test coverage for the finger table, hashing utilities, and node logic, as well as configuration updates to support packaging and distribution.

**Packaging and Build System Updates**
* Added `[build-system]` configuration to `pyproject.toml` to specify `hatchling` as the build backend, enabling wheel builds for the project.
* Configured wheel packaging to include the `src` directory via `[tool.hatch.build.targets.wheel]` in `pyproject.toml`.

**New Unit Test Suites**
* Added `tests/unit/test_finger_table.py` with extensive tests for `FingerTable` initialization, operations, successor logic, closest preceding node search, and refresh target calculations.
* Added `tests/unit/test_hashing.py` to verify consistent hashing utilities, including `dht_hash` and `is_between`, covering normal, wraparound, and edge cases.
* Added `tests/unit/test_node.py` to test `ChordNode` initialization, key responsibility, routing, stabilization, notification, and state update methods.