### PR TITLE
FastAPI File Routes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "httpx>=0.28.1",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.12.0",
+    "python-multipart>=0.0.22",
     "uvicorn>=0.40.0",
 ]
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from src.api.routes.files import router as files_router
 from src.config import Settings, get_settings
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # Store settings in app state for access in lifespan and routes
     app.state.settings = settings
 
-    # TODO: Register routes
+    # Register routes
+    app.include_router(files_router)
 
     return app

--- a/src/api/routes/__init__.py
+++ b/src/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API route modules."""

--- a/src/api/routes/files.py
+++ b/src/api/routes/files.py
@@ -1,0 +1,83 @@
+"""File routes for the Chord DFS API."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi.responses import Response
+
+from src.api.schemas.files import (
+    FileDeleteResponse,
+    FileListResponse,
+    FileUploadResponse,
+)
+
+router = APIRouter(prefix="/files", tags=["files"])
+
+# Type alias for file upload dependency
+UploadFileDep = Annotated[UploadFile, File()]
+
+
+@router.post("", response_model=FileUploadResponse, status_code=201)
+async def upload_file(file: UploadFileDep) -> FileUploadResponse:
+    """Upload a file to the distributed file system.
+
+    The file will be stored on the node responsible for its key
+    (determined by hashing the filename).
+    """
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No filename provided")
+
+    # TODO: Implement with node service
+
+    return FileUploadResponse(
+        message=f"File {file.filename} uploaded successfully",
+        filename=file.filename,
+    )
+
+
+@router.get("", response_model=FileListResponse)
+async def list_files() -> FileListResponse:
+    """List all files stored on the ring."""
+    # TODO: Implement with node service
+    files: list[str] = []
+    return FileListResponse(files=files)
+
+
+@router.get("/{filename}")
+async def get_file(filename: str) -> Response:
+    """Download a file from the distributed file system.
+
+    The request will be routed to the node responsible for the file.
+    """
+    # TODO: Implement with node service
+
+    raise HTTPException(status_code=404, detail="File not found")
+
+
+@router.delete("/{filename}", response_model=FileDeleteResponse)
+async def delete_file(filename: str) -> FileDeleteResponse:
+    """Delete a file from the distributed file system."""
+    # TODO: Implement with node service
+    raise HTTPException(status_code=404, detail="File not found")
+
+
+@router.post("/forward", response_model=FileUploadResponse, status_code=201)
+async def forward_file(file: UploadFileDep) -> FileUploadResponse:
+    """Internal endpoint for forwarding files between nodes."""
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No filename provided")
+
+    # TODO: Implement with node service
+
+    return FileUploadResponse(
+        message="File stored successfully",
+        filename=file.filename or "",
+    )
+
+
+@router.get("/list/local", response_model=FileListResponse)
+async def list_local_files() -> FileListResponse:
+    """List files stored locally on this node."""
+    # TODO: Implement with node service
+    files: list[str] = []
+    return FileListResponse(files=files)

--- a/src/api/schemas/__init__.py
+++ b/src/api/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic schemas for API request/response models."""

--- a/src/api/schemas/files.py
+++ b/src/api/schemas/files.py
@@ -1,0 +1,29 @@
+"""Pydantic schemas for file operations."""
+
+from pydantic import BaseModel
+
+
+class FileUploadResponse(BaseModel):
+    """Response for successful file upload."""
+
+    message: str
+    filename: str
+
+
+class FileDeleteResponse(BaseModel):
+    """Response for successful file deletion."""
+
+    message: str
+    filename: str
+
+
+class FileListResponse(BaseModel):
+    """Response for listing files."""
+
+    files: list[str]
+
+
+class ErrorResponse(BaseModel):
+    """Response for error cases."""
+
+    error: str

--- a/uv.lock
+++ b/uv.lock
@@ -69,6 +69,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "uvicorn" },
 ]
 
@@ -88,6 +89,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
+    { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "uvicorn", specifier = ">=0.40.0" },
 ]
 
@@ -471,6 +473,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request adds foundational support for file operations in the API, including route definitions and Pydantic schemas for file-related endpoints. It introduces a new `files` route group, implements placeholder endpoints for file upload, download, listing, deletion, and internal forwarding, and registers these routes with the FastAPI application. Additionally, it adds necessary dependencies for file uploads and introduces schema models for consistent API responses.

**API route and endpoint additions:**

* Added `src/api/routes/files.py` with new endpoints for file upload, download, listing (all and local), deletion, and internal forwarding, all with placeholder implementations and proper response models.
* Registered the new `files` router in the FastAPI app by importing and including it in the application setup (`src/api/app.py`). [[1]](diffhunk://#diff-dc5c3ef4b3c46ab4dd70d6066f139050bb3d83acd161cb30b59b7552741b3269R9) [[2]](diffhunk://#diff-dc5c3ef4b3c46ab4dd70d6066f139050bb3d83acd161cb30b59b7552741b3269L68-R70)
* Added module docstrings to `src/api/routes/__init__.py` and `src/api/schemas/__init__.py` for clarity and documentation. [[1]](diffhunk://#diff-0e19625e954c9dd26a7aecad2d310a3a8353ed0847046c918afbfbd29e9c2447R1) [[2]](diffhunk://#diff-a0ce84e9b396e9960e6c4907c7a96145c34d5cc5ac805f08dbc7ed6184ac281eR1)

**Schema/model improvements:**

* Created `src/api/schemas/files.py` defining Pydantic models for file upload, delete, list, and error responses, ensuring consistent API response structure.

**Dependency updates:**

* Added `python-multipart` to `pyproject.toml` dependencies to enable file uploads via FastAPI.